### PR TITLE
Allow script to be placed into body sans callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 
-Use the Financial Times' [polyfill.io](https://polyfill.io/v2/docs/) service in your webpack builds with the help of the [`HtmlWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin#html-webpack-plugin).
+Use the Financial Times' [polyfill.io](https://polyfill.io/v3/docs/) service in your webpack builds with the help of the [`HtmlWebpackPlugin`](https://github.com/jantimon/html-webpack-plugin#html-webpack-plugin).
 
 ## Installation
 
@@ -38,7 +38,7 @@ module.exports = {
 
 ## Configuration
 
-The plugin's configuration mirrors that listed at [polyfill.io/v2/docs/api](https://polyfill.io/v2/docs/api) when possible. Documentation here is minimal to avoid duplicating the official documentation.
+The plugin's configuration mirrors that listed at [polyfill.io/v3/docs/api](https://polyfill.io/v3/docs/api) when possible. Documentation here is minimal to avoid duplicating the official documentation.
 
 ### (`minify`: `boolean`)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ What to do when the user agent is not recognized.
 
 Explicitly enable or diable [real user monitoring](https://en.wikipedia.org/wiki/Real_user_monitoring)
 
+### (`useBody`: `boolean`)
+
+default: false
+
+Place the polyfill script in the body rather than the head.
+
 ## Example
 
 ```js

--- a/__snapshots__/integration.test.js.snap
+++ b/__snapshots__/integration.test.js.snap
@@ -35,3 +35,15 @@ exports[`HtmlWebpackPolyfillIOPlugin with configuration adds the polyfill script
   <script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
 </html>"
 `;
+
+exports[`HtmlWebpackPolyfillIOPlugin with useBody adds the polyfill script to the body 1`] = `
+"<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset=\\"UTF-8\\">
+    <title>Webpack App</title>
+  </head>
+  <body>
+  <script src=\\"https://cdn.polyfill.io/v2/polyfill.js\\"></script><script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
+</html>"
+`;

--- a/__snapshots__/integration.test.js.snap
+++ b/__snapshots__/integration.test.js.snap
@@ -6,7 +6,7 @@ exports[`HtmlWebpackPolyfillIOPlugin simple adds the polyfill script to the head
   <head>
     <meta charset=\\"UTF-8\\">
     <title>Webpack App</title>
-  <script src=\\"https://cdn.polyfill.io/v2/polyfill.js\\"></script></head>
+  <script src=\\"https://cdn.polyfill.io/v3/polyfill.js\\"></script></head>
   <body>
   <script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
 </html>"
@@ -18,9 +18,9 @@ exports[`HtmlWebpackPolyfillIOPlugin with callback adds the polyfill script to t
   <head>
     <meta charset=\\"UTF-8\\">
     <title>Webpack App</title>
-  <link href=\\"https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6&flags=gated&callback=ready&rum=1\\" type=\\"preload\\" as=\\"script\\"></head>
+  <link href=\\"https://cdn.polyfill.io/v3/polyfill.min.js?features=default-3.6&flags=gated&callback=ready&rum=1\\" type=\\"preload\\" as=\\"script\\"></head>
   <body>
-  <script src=\\"https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6&flags=gated&callback=ready&rum=1\\" async></script><script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
+  <script src=\\"https://cdn.polyfill.io/v3/polyfill.min.js?features=default-3.6&flags=gated&callback=ready&rum=1\\" async></script><script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
 </html>"
 `;
 
@@ -30,7 +30,7 @@ exports[`HtmlWebpackPolyfillIOPlugin with configuration adds the polyfill script
   <head>
     <meta charset=\\"UTF-8\\">
     <title>Webpack App</title>
-  <script src=\\"https://cdn.polyfill.io/v2/polyfill.min.js?features=default-3.6&flags=gated&rum=1\\"></script></head>
+  <script src=\\"https://cdn.polyfill.io/v3/polyfill.min.js?features=default-3.6&flags=gated&rum=1\\"></script></head>
   <body>
   <script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
 </html>"
@@ -44,6 +44,6 @@ exports[`HtmlWebpackPolyfillIOPlugin with useBody adds the polyfill script to th
     <title>Webpack App</title>
   </head>
   <body>
-  <script src=\\"https://cdn.polyfill.io/v2/polyfill.js\\"></script><script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
+  <script src=\\"https://cdn.polyfill.io/v3/polyfill.js\\"></script><script type=\\"text/javascript\\" src=\\"main.js\\"></script></body>
 </html>"
 `;

--- a/index.js
+++ b/index.js
@@ -58,6 +58,10 @@ class HtmlWebpackPolyfillIOPlugin {
       )
 
     if (isDefined(options.rum)) this.options.rum = Boolean(options.rum)
+
+    this.options.useBody = (isDefined(options.useBody))
+      ? Boolean(options.useBody)
+      : false
   }
 
   buildSrc() {
@@ -117,6 +121,9 @@ class HtmlWebpackPolyfillIOPlugin {
         if (this.options.callback) {
           const hint = this.buildHintTag()
           data.head.push(hint)
+        }
+
+        if (this.options.useBody || this.options.callback) {
           data.body.unshift(script)
         } else {
           data.head.push(script)

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class HtmlWebpackPolyfillIOPlugin {
   }
 
   buildSrc() {
-    const base = 'https://cdn.polyfill.io/v2/polyfill.'
+    const base = 'https://cdn.polyfill.io/v3/polyfill.'
     const postfix = this.options.minify ? 'min.js' : 'js'
 
     const options = []

--- a/integration.test.js
+++ b/integration.test.js
@@ -58,6 +58,19 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
       )
     })
   })
+  describe('with useBody', () => {
+   it('adds the polyfill script to the body', done => {
+      compile(
+        {
+          useBody: true,
+        },
+        html => {
+          expect(html).toMatchSnapshot()
+          done()
+        }
+      )
+    })
+  })
   describe('with callback', () => {
     it('adds the polyfill script to the body and a resource hint to the head', done => {
       compile(

--- a/unit.test.js
+++ b/unit.test.js
@@ -211,7 +211,7 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
   describe('buildSrc', () => {
     const plugin = new HtmlWebpackPolyfillIOPlugin()
     it('builds a polyfill url', () => {
-      expect(plugin.buildSrc()).toBe('https://cdn.polyfill.io/v2/polyfill.js')
+      expect(plugin.buildSrc()).toBe('https://cdn.polyfill.io/v3/polyfill.js')
     })
 
     describe('minify', () => {
@@ -219,7 +219,7 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
         beforeAll(() => (plugin.options.minify = true))
         it('targets the minified script', () => {
           expect(plugin.buildSrc()).toBe(
-            'https://cdn.polyfill.io/v2/polyfill.min.js'
+            'https://cdn.polyfill.io/v3/polyfill.min.js'
           )
         })
       })
@@ -227,7 +227,7 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
         beforeAll(() => (plugin.options.minify = false))
         it('targets the non-minified script', () => {
           expect(plugin.buildSrc()).toBe(
-            'https://cdn.polyfill.io/v2/polyfill.js'
+            'https://cdn.polyfill.io/v3/polyfill.js'
           )
         })
       })
@@ -377,12 +377,12 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
       beforeEach(() => {
         jest
           .spyOn(plugin, 'buildSrc')
-          .mockReturnValueOnce('https://cdn.polyfill.io/v2/polyfill.min.js')
+          .mockReturnValueOnce('https://cdn.polyfill.io/v3/polyfill.min.js')
       })
       it('calls buildSrc and uses the returned value', () => {
         const attrs = plugin.buildScriptAttrs()
         expect(plugin.buildSrc).toHaveBeenCalledTimes(1)
-        expect(attrs.src).toBe('https://cdn.polyfill.io/v2/polyfill.min.js')
+        expect(attrs.src).toBe('https://cdn.polyfill.io/v3/polyfill.min.js')
       })
     })
     describe('async', () => {
@@ -417,7 +417,7 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
       })
     })
     describe('attributes', () => {
-      const attributes = { src: 'https://cdn.polyfill.io/v2/polyfill.min.js' }
+      const attributes = { src: 'https://cdn.polyfill.io/v3/polyfill.min.js' }
       beforeEach(() => {
         jest.spyOn(plugin, 'buildScriptAttrs').mockReturnValueOnce(attributes)
       })

--- a/unit.test.js
+++ b/unit.test.js
@@ -185,6 +185,27 @@ describe('HtmlWebpackPolyfillIOPlugin', () => {
         })
       })
     })
+    describe('useBody', () => {
+      describe('true', () => {
+        it('sets useBody true', () => {
+          const options = new HtmlWebpackPolyfillIOPlugin({ useBody: true }).options
+          expect(options.useBody).toBe(true)
+        })
+      })
+      describe('false', () => {
+        it('sets useBody false', () => {
+          const options = new HtmlWebpackPolyfillIOPlugin({ useBody: false })
+            .options
+          expect(options.useBody).toBe(false)
+        })
+      })
+      describe('default', () => {
+        it('should be false', () => {
+          const options = new HtmlWebpackPolyfillIOPlugin().options
+          expect(options.useBody).toBe(false)
+        })
+      })
+    })
   })
 
   describe('buildSrc', () => {


### PR DESCRIPTION
As requested in
https://github.com/zperrault/html-webpack-polyfill-io-plugin/issues/1 it
would be nice to allow the polyfill.io script to be placed as the first
script in the body, rather than blocking initial render.

Fixes #1